### PR TITLE
Update src.pro

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -8,6 +8,7 @@ CONFIG(debug, debug|release):TARGET = openhomm3d
 else:TARGET = openhomm3
 CONFIG += warn_on
 QT += opengl core-private widgets
+LIBS += -lopengl32 -lglu32
 TEMPLATE = app
 VPATH += .
 INCLUDEPATH += . \


### PR DESCRIPTION
Fix linkage on qt 5.5/win.

Without this libs linkage fails with:

> g++ -c -include release\precompiled.hpp -pipe -fno-keep-inline-dllexport -O2 -Wall -Wextra -frtti -fexceptions -mthreads -DUNICODE -DQT_DEPRECATED_WARNINGS -DQT_NO_DEBUG -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I....\src -I. -I....\src\core -I....\src\game -I....\src\game\map -I....\src\gui -I....\src\render -I....\src -I....\src\game -I....\src\gui -I....\src\render -I....\src\core -IC:\Qt\5.5\mingw492_32\include -IC:\Qt\5.5\mingw492_32\include\QtOpenGL -IC:\Qt\5.5\mingw492_32\include\QtWidgets -IC:\Qt\5.5\mingw492_32\include\QtGui -IC:\Qt\5.5\mingw492_32\include\QtANGLE -IC:\Qt\5.5\mingw492_32\include\QtCore\5.5.1 -IC:\Qt\5.5\mingw492_32\include\QtCore\5.5.1\QtCore -IC:\Qt\5.5\mingw492_32\include\QtCore -I....\moc\release -IC:\Qt\5.5\mingw492_32\mkspecs\win32-g++  -o ....\obj\release\moc_hrApplication.o ....\moc\release\moc_hrApplication.cpp
> g++ -Wl,-s -Wl,-subsystem,console -mthreads -o ....\bin\release\openhomm3.exe object_script.openhomm3.Release  -lz -LC:/Qt/5.5/mingw492_32/lib -lQt5OpenGL -lQt5Widgets -lQt5Gui -lQt5Core 
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x25a): undefined reference to `_imp__glViewport@16'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x26a): undefined reference to`_imp__glMatrixMode@4'
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x273): undefined reference to `_imp__glLoadIdentity@0'
> Makefile.Release:185: recipe for target '..\..\bin\release\openhomm3.exe' failed
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x2a7): undefined reference to`_imp__glOrtho@48'
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x2c1): undefined reference to `_imp__glScalef@12'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x3fc): undefined reference to`_imp__glBindTexture@8'
> mingw32-make[2]: Leaving directory 'C:/Users/Mykola/Downloads/openhomm-master/build-Desktop_Qt_5_5_1_MinGW_32bit-Release/src'
> Makefile:34: recipe for target 'release' failed
> mingw32-make[1]: Leaving directory 'C:/Users/Mykola/Downloads/openhomm-master/build-Desktop_Qt_5_5_1_MinGW_32bit-Release/src'
> makefile:39: recipe for target 'sub-src-make_first' failed
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x41b): undefined reference to `_imp__glEnable@4'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x499): undefined reference to`_imp__glVertexPointer@16'
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x4c1): undefined reference to `_imp__glTexCoordPointer@16'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x4e1): undefined reference to`_imp__glDrawArrays@12'
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x4f4): undefined reference to `_imp__glDisable@4'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x6e0): undefined reference to`_imp__glGetString@4'
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x7be): undefined reference to `_imp__glViewport@16'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x7ce): undefined reference to`_imp__glMatrixMode@4'
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x7d7): undefined reference to `_imp__glLoadIdentity@0'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x821): undefined reference to`_imp__glOrtho@48'
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x82a): undefined reference to `_imp__glDisable@4'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x85b): undefined reference to`_imp__glShadeModel@4'
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x873): undefined reference to `_imp__glBlendFunc@8'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x883): undefined reference to`_imp__glEnable@4'
> ./....\obj\release\hrRender.o:hrRender.cpp:(.text+0x88c): undefined reference to `_imp__glEnableClientState@4'
> ./..\..\obj\release\hrRender.o:hrRender.cpp:(.text+0x923): undefined reference to`_imp__glClear@4'
> C:/Qt/Tools/mingw492_32/bin/../lib/gcc/i686-w64-mingw32/4.9.2/../../../../i686-w64-mingw32/bin/ld.exe: ./....\obj\release\hrRender.o: bad reloc address 0x20 in section `.eh_frame'
> collect2.exe: error: ld returned 1 exit status
> mingw32-make[2]: **\* [....\bin\release\openhomm3.exe] Error 1
> mingw32-make[1]: **\* [release] Error 2
> mingw32-make: **\* [sub-src-make_first] Error 2
> 11:15:16: The process "C:\Qt\Tools\mingw492_32\bin\mingw32-make.exe" exited with code 2.
> Error while building/deploying project openhomm (kit: Desktop Qt 5.5.1 MinGW 32bit)
> When executing step "Make"
> 11:15:16: Elapsed time: 00:26.
